### PR TITLE
Update parser.py to cast correctly boolean plugs

### DIFF
--- a/src/guerilla_parser/parser.py
+++ b/src/guerilla_parser/parser.py
@@ -398,7 +398,7 @@ class GuerillaParser(object):
                         if param is not None:
                             param = self.__lua_dict_to_python(param)
                     elif plug_type == 'types.bool':
-                        value = bool(value)
+                        value = self._LUA_TO_PY_BOOL[value]
                     elif plug_type == 'types.int':
                         value = int(value)
                         if param is not None:


### PR DESCRIPTION
Fix the incorrect casting (str->bool) from Lua value to Python type wich always return True when parsing for boolean plug. I switched it with the _LUA_TO_PY_BOOL lookup dict